### PR TITLE
update to latest, clean up derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646254136,
-        "narHash": "sha256-8nQx02tTzgYO21BP/dy5BCRopE8OwE8Drsw98j+Qoaw=",
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e072546ea98db00c2364b81491b893673267827",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- we don't need a list of executables when we can just pattern-match
- libraries should go into the `lib` dir
- we don't need the `opt` dir, just `bin` and `lib`
- `phases` works, but is not allowed in nixpkgs, so we should always avoid it
- patching things should happen in the patch phase, not fixup phase